### PR TITLE
New script to ease setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ iptables*
 analysis
 
 testing
+
+data/
+
+venv/

--- a/README.md
+++ b/README.md
@@ -29,40 +29,38 @@ Ubuntu packages:
 
 `sudo apt install coinor-clp coinor-cbc python3-venv redis-server`
 
-In addition for a server deployment:
-
-`sudo apt install nginx`
-
 Python:
 
-`pip install ipython pandas numpy redis rq Flask xarray netcdf4 json`
+	python3 -m venv venv
+	. venv/bin/activate
+	pip install -r requirements.txt
 
-`pip install git+https://github.com/PyPSA/PyPSA.git`
+For (optional) server deployment:
 
-In addition for a server deployment:
+	sudo apt install nginx
+	pip install gunicorn
 
-`pip install gunicorn`
+### Preparation
 
+After installing the dependencies above, run the following line of code:
+
+	python prepare.py
+
+This helps you:
+
+1. Fetch the weather data described below
+1. Convert it to netCDF
+1. Create folders for results
+1. Fetch static files not included in this repository
+
+Now you are ready to [run the server locally](#run-server-locally-on-your-own-computer).
 
 ### Data
 
-For the wind and solar generation time series, get from the [renewables.ninja download page](https://www.renewables.ninja/downloads):
+For the wind and solar generation time series, we use the following from the [renewables.ninja download page](https://www.renewables.ninja/downloads):
 
 - Solar time series `ninja_pv_europe_v1.1_sarah.csv` from "PV v1.1 Europe"
-
 - Wind time series `ninja_wind_europe_v1.1_current_on-offshore.csv` from "Wind v1.1 Europe"
-
-
-Convert them to netCDF format with:
-
-```python
-import xarray as xr
-import pandas as pd
-solar_pu = pd.read_csv('ninja_pv_europe_v1.1_sarah.csv',
-                       index_col=0, parse_dates=True)
-ds = xr.Dataset.from_dataframe(solar_pu)
-ds.to_netcdf('ninja_pv_europe_v1.1_sarah.nc')
-```
 
 ## Run without server
 

--- a/prepare.py
+++ b/prepare.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import xarray as xr
+import pandas as pd
+
+# Get weather data from renewables.ninja
+os.makedirs('data', exist_ok=True)
+subprocess.call(['wget', '-O', 'data/ninja_europe_pv_v1.1.zip',
+                 'https://www.renewables.ninja/static/downloads/ninja_europe_pv_v1.1.zip'])
+subprocess.call(['wget', '-O', 'data/ninja_europe_wind_v1.1.zip',
+                 'https://www.renewables.ninja/static/downloads/ninja_europe_wind_v1.1.zip'])
+subprocess.call(['unzip', 'data/*', '-d', 'data/'])
+
+# Convert data to netCDF
+solar_pu = pd.read_csv('data/ninja_pv_europe_v1.1_sarah.csv',
+                       index_col=0, parse_dates=True)
+ds = xr.Dataset.from_dataframe(solar_pu)
+ds.to_netcdf('data/ninja_pv_europe_v1.1_sarah.nc')
+
+wind_pu = pd.read_csv(
+    'data/ninja_wind_europe_v1.1_current_on-offshore.csv', index_col=0, parse_dates=True)
+ds = xr.Dataset.from_dataframe(wind_pu)
+ds.to_netcdf('data/ninja_wind_europe_v1.1_current_on-offshore.nc')
+
+# Create folders for results
+os.makedirs('results', exist_ok=True)
+os.makedirs('results-solve', exist_ok=True)
+os.makedirs('assumptions', exist_ok=True)
+
+# Get static files excluded from repo
+subprocess.call(['wget', '-O', 'static/d3-tip.js',
+                 'https://model.energy/static/d3-tip.js'])
+subprocess.call(['wget', '-O', 'static/d3.v4.min.js',
+                 'https://model.energy/static/d3.v4.min.js'])
+subprocess.call(['wget', '-O', 'static/ne_50m_admin_0_countries_simplified_europe.json',
+                 'https://model.energy/static/ne_50m_admin_0_countries_simplified_europe.json'])
+subprocess.call(['wget', '-O', 'static/results-initial.json',
+                 'https://model.energy/static/results-initial.json'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+ipython
+pandas
+numpy
+redis
+rq
+Flask
+xarray
+netcdf4
+git+https://github.com/PyPSA/PyPSA.git

--- a/solve.py
+++ b/solve.py
@@ -28,10 +28,10 @@ import xarray as xr
 
 
 #read in renewables.ninja solar time series
-solar_pu = xr.open_dataset('ninja_pv_europe_v1.1_sarah.nc')
+solar_pu = xr.open_dataset('data/ninja_pv_europe_v1.1_sarah.nc')
 
 #read in renewables.ninja wind time series
-wind_pu = xr.open_dataset('ninja_wind_europe_v1.1_current_on-offshore.nc')
+wind_pu = xr.open_dataset('data/ninja_wind_europe_v1.1_current_on-offshore.nc')
 
 
 colors = {"wind":"#3B6182",


### PR DESCRIPTION
I've added a new script `prepare.py`, which eases the setup process for new users/developers. The README has been updated accordingly.

There are some static files required, which are currently not included in the repository. These are fetched as part of the new `prepare.py`. I suggest that the d3 libraries either be included in the repo or loaded through a CDN. I think it's okay to fetch `results-initial.json` from [model.energy](https://model.energy).